### PR TITLE
feat: WeatherKit 연동 및 UV 지수 표시

### DIFF
--- a/TarTanning/TarTanning/Core/Managers/WeatherManager.swift
+++ b/TarTanning/TarTanning/Core/Managers/WeatherManager.swift
@@ -5,4 +5,48 @@
 //  Created by Jun on 7/14/25.
 //
 
+import CoreLocation
 import Foundation
+import WeatherKit
+
+//MARK: 임시 데이터 모델
+struct UVInfo {
+    let value: Int
+    let category: String
+}
+
+final class WeatherKitManager {
+    static let shared = WeatherKitManager()
+    private init() {}
+
+    private let weatherService = WeatherService.shared
+
+    func fetchUVInfo(for location: CLLocation) async -> UVInfo? {
+        do {
+            let weather = try await weatherService.weather(for: location)
+            let uvIndex = weather.currentWeather.uvIndex
+            
+            let categoryString: String
+            switch uvIndex.category {
+            case .low:
+                categoryString = "낮음"
+            case .moderate:
+                categoryString = "보통"
+            case .high:
+                categoryString = "높음"
+            case .veryHigh:
+                categoryString = "매우 높음"
+            case .extreme:
+                categoryString = "위험"
+            @unknown default:
+                categoryString = "알 수 없음"
+            }
+            
+            return UVInfo(value: uvIndex.value, category: categoryString)
+            
+        } catch {
+            print("WeatherKit 데이터 가져오기 실패: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/TarTanning/TarTanning/Core/Managers/WeatherManager.swift
+++ b/TarTanning/TarTanning/Core/Managers/WeatherManager.swift
@@ -9,7 +9,6 @@ import CoreLocation
 import Foundation
 import WeatherKit
 
-//MARK: 임시 데이터 모델
 struct UVInfo {
     let value: Int
     let category: String

--- a/TarTanning/TarTanning/Features/Weather/View/WeatherView.swift
+++ b/TarTanning/TarTanning/Features/Weather/View/WeatherView.swift
@@ -1,0 +1,36 @@
+//
+//  WeatherView.swift
+//  TarTanning
+//
+//  Created by Jun on 7/14/25.
+//
+
+import SwiftUI
+
+struct WeatherView: View {
+    @StateObject private var viewModel = WeatherViewModel()
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Weather Test")
+                .font(.title)
+                .fontWeight(.bold)
+
+            Button("포항 UV 지수 로그 확인") {
+                viewModel.fetchSydneyUVIndex()
+            }
+            .buttonStyle(.borderedProminent)
+            .padding()
+
+            if viewModel.isLoading {
+                ProgressView("UV 지수 가져오는 중...")
+                    .progressViewStyle(CircularProgressViewStyle())
+            }
+        }
+        .navigationTitle("Weather")
+    }
+}
+
+#Preview {
+    WeatherView()
+}

--- a/TarTanning/TarTanning/Features/Weather/ViewModel/WeatherViewModel.swift
+++ b/TarTanning/TarTanning/Features/Weather/ViewModel/WeatherViewModel.swift
@@ -1,0 +1,54 @@
+//
+//  WeatherViewModel.swift
+//  TarTanning
+//
+//  Created by Jun on 7/14/25.
+//
+
+import CoreLocation
+import Foundation
+
+@MainActor
+class WeatherViewModel: ObservableObject {
+
+    @Published var isLoading = false
+
+    // 시드니 위치 정보
+    private let sydneyLocation = CLLocation(
+        latitude: 36.019627041036635,  // 시드니 위도
+        longitude: 129.34578962547744  // 시드니 경도
+    )
+
+    func fetchSydneyUVIndex() {
+        print("🌍 포항 UV 지수 확인 시작...")
+        print(
+            "📍 위치: 포항 (위도: \(sydneyLocation.coordinate.latitude), 경도: \(sydneyLocation.coordinate.longitude))"
+        )
+
+        isLoading = true
+
+        Task {
+            print("⏳ WeatherKitManager를 통해 UV 지수 요청 중...")
+
+            // WeatherKitManager를 사용해서 시드니의 UV 지수 가져오기
+            if let uvInfo = await WeatherKitManager.shared.fetchUVInfo(
+                for: sydneyLocation
+            ) {
+                print("✅ UV 지수 가져오기 성공!")
+                print("📊 UV 지수: \(uvInfo.value)")
+                print("📝 UV 지수 카테고리: \(uvInfo.category)")
+                print("🕐 시간: \(Date())")
+
+            } else {
+                print("❌ UV 지수를 가져올 수 없습니다.")
+                print("🔍 가능한 원인:")
+                print("   - 네트워크 연결 문제")
+                print("   - WeatherKit 권한 문제")
+                print("   - 위치 정보 오류")
+            }
+
+            isLoading = false
+            print("🏁 시드니 UV 지수 확인 완료\n")
+        }
+    }
+}

--- a/TarTanning/TarTanning/Features/Weather/ViewModel/WeatherViewModel.swift
+++ b/TarTanning/TarTanning/Features/Weather/ViewModel/WeatherViewModel.swift
@@ -14,15 +14,15 @@ class WeatherViewModel: ObservableObject {
     @Published var isLoading = false
 
     // 시드니 위치 정보
-    private let sydneyLocation = CLLocation(
-        latitude: 36.019627041036635,  // 시드니 위도
-        longitude: 129.34578962547744  // 시드니 경도
+    private let poHangLocation = CLLocation(
+        latitude: 36.019627041036635,  // 포항 위도
+        longitude: 129.34578962547744  // 포항 경도
     )
 
     func fetchSydneyUVIndex() {
         print("🌍 포항 UV 지수 확인 시작...")
         print(
-            "📍 위치: 포항 (위도: \(sydneyLocation.coordinate.latitude), 경도: \(sydneyLocation.coordinate.longitude))"
+            "📍 위치: 포항 (위도: \(poHangLocation.coordinate.latitude), 경도: \(poHangLocation.coordinate.longitude))"
         )
 
         isLoading = true
@@ -32,7 +32,7 @@ class WeatherViewModel: ObservableObject {
 
             // WeatherKitManager를 사용해서 시드니의 UV 지수 가져오기
             if let uvInfo = await WeatherKitManager.shared.fetchUVInfo(
-                for: sydneyLocation
+                for: poHangLocation
             ) {
                 print("✅ UV 지수 가져오기 성공!")
                 print("📊 UV 지수: \(uvInfo.value)")
@@ -48,7 +48,7 @@ class WeatherViewModel: ObservableObject {
             }
 
             isLoading = false
-            print("🏁 시드니 UV 지수 확인 완료\n")
+            print("🏁 포항 UV 지수 확인 완료\n")
         }
     }
 }


### PR DESCRIPTION
---
"[PR] WeatherKit 연동 및 UV 지수 표시"
---

## #️⃣ 연관된 이슈
> #3 

## #️⃣ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)
- WeatherKitManager를 통해 시드니의 UV 지수 및 카테고리(낮음, 보통, 높음 등) 조회 기능 구현
- WeatherView/WeatherViewModel 생성: 버튼 클릭 시 포항(Mock) UV 지수와 카테고리를 로그로 출력

* 이미지에는 `시드니`라고 나오나, 현재는 포항 위도/경도 사용함
<img width="354" height="137" alt="image" src="https://github.com/user-attachments/assets/589ecc7b-35b4-47fb-8b4f-d30c1851e14e" />


## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등
- 실제 기기에서 WeatherView의 버튼 클릭 시 콘솔에 UV 지수와 카테고리가 정상적으로 출력됨을 확인
- 잘못된 위도 경도 입력 시 error 출력됨
- 앱 크래시 및 빌드 에러 없음

## #️⃣ 변경 사항 체크리스트
- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

시뮬레이터가 아닌 실제 기기에서 작동해야 로그가 나옵니다.

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요
