### PR TITLE
feat: dashboard 디자인 수정(이모지 삭제), 컬러에셋 추가

### DIFF
--- a/TarTanning/TarTanning/Features/Dashboard/View/SubViews/DashboardWeeklySummaryView.swift
+++ b/TarTanning/TarTanning/Features/Dashboard/View/SubViews/DashboardWeeklySummaryView.swift
@@ -81,18 +81,15 @@ struct WeeklyDayRowView: View {
         Text(data.day)
           .foregroundColor(.primary)
           .frame(width: geometry.size.width * 0.2, alignment: .leading)
-        
         VStack(spacing: 2) {
           Text("\(Int(data.progress * 100))%")
             .foregroundColor(.gray)
             .frame(maxWidth: .infinity, alignment: .trailing)
-          
           ZStack(alignment: .leading) {
             Rectangle()
               .fill(Color.gray.opacity(0.2))
               .frame(height: 6)
               .cornerRadius(3)
-            
             Rectangle()
               .fill(data.color)
               .frame(width: max(0, min(1.0, data.progress)) * (geometry.size.width * 0.8))

--- a/TarTanning/TarTanning/Features/Dashboard/View/SubViews/DashboardWeeklySummaryView.swift
+++ b/TarTanning/TarTanning/Features/Dashboard/View/SubViews/DashboardWeeklySummaryView.swift
@@ -8,141 +8,129 @@
 import SwiftUI
 
 struct DashboardWeeklySummaryView: View {
-    @ObservedObject var viewModel: DashboardViewModel
-    
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            WeeklySummaryTitleView()
-            WeeklySummaryDataView(weeklyProgressRates: viewModel.weeklyUVProgressRates)
-        }
+  @ObservedObject var viewModel: DashboardViewModel
+  
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      WeeklySummaryTitleView()
+      WeeklySummaryDataView(weeklyProgressRates: viewModel.weeklyUVProgressRates)
     }
+  }
 }
 
 struct WeeklySummaryTitleView: View {
-    var body: some View {
-        HStack {
-            Text("주간 요약")
-            Spacer()
-        }
+  var body: some View {
+    HStack {
+      Text("주간 요약")
+      Spacer()
     }
+  }
 }
 
 struct WeeklySummaryDataView: View {
-    let weeklyProgressRates: [Double]
-    
-    private var weeklyData: [WeeklyDayData] {
-        return weeklyProgressRates.enumerated().map { index, progress in
-            let dayString = "\(index + 1) 일전"
-            let (color, emoji) = getColorAndEmoji(for: progress)
-            
-            return WeeklyDayData(
-                day: dayString,
-                progress: progress,
-                color: color,
-                emoji: emoji
-            )
-        }
+  let weeklyProgressRates: [Double]
+  
+  private var weeklyData: [WeeklyDayData] {
+    return weeklyProgressRates.enumerated().map { index, progress in
+      let dayString = "\(index + 1) 일전"
+      let color = getColor(for: progress)
+      
+      return WeeklyDayData(
+        day: dayString,
+        progress: progress,
+        color: color
+      )
     }
-    
-    private func getColorAndEmoji(for progress: Double) -> (Color, String) {
-        switch progress {
-        case 0.0..<0.3:
-            return (.blue, "😆")
-        case 0.3..<0.7:
-            return (.orange, "🙂")
-        case 0.7..<1.0:
-            return (.red, "😔")
-        default:
-            return (.black, "🔥")
-        }
+  }
+  
+  private func getColor(for progress: Double) -> (Color) {
+    switch progress {
+    case 0.0..<0.3:
+      return (.blue)
+    case 0.3..<0.7:
+      return (.orange)
+    case 0.7..<1.0:
+      return (.red)
+    default:
+      return (.black)
     }
-    
-    var body: some View {
-        if weeklyProgressRates.isEmpty || weeklyProgressRates.allSatisfy({ $0 == 0 }) {
-            EmptyWeeklyDataView()
-        } else {
-            VStack(spacing: 8) {
-                ForEach(weeklyData, id: \.day) { data in
-                    WeeklyDayRowView(data: data)
-                }
-            }
-            .padding(16)
-            .background(Color.white)
-            .cornerRadius(12)
+  }
+  
+  var body: some View {
+    if weeklyProgressRates.isEmpty || weeklyProgressRates.allSatisfy({ $0 == 0 }) {
+      EmptyWeeklyDataView()
+    } else {
+      VStack(spacing: 8) {
+        ForEach(weeklyData, id: \.day) { data in
+          WeeklyDayRowView(data: data)
         }
+      }
+      .padding(16)
+      .background(Color.white)
+      .cornerRadius(12)
     }
+  }
 }
 
 struct WeeklyDayRowView: View {
-    let data: WeeklyDayData
-    
-    var body: some View {
-        GeometryReader { geometry in
-            HStack(spacing: 0) {
-                Text(data.day)
-                    .foregroundColor(.primary)
-                    .frame(width: geometry.size.width * 0.2, alignment: .leading)
-                
-                Circle()
-                    .fill(data.color.opacity(0.2))
-                    .frame(width: 24, height: 24)
-                    .overlay(
-                        Text(data.emoji)
-                    )
-                    .frame(width: geometry.size.width * 0.15, alignment: .center)
-                
-                VStack(spacing: 2) {
-                    Text("\(Int(data.progress * 100))%")
-                        .foregroundColor(.gray)
-                        .frame(maxWidth: .infinity, alignment: .trailing)
-                    
-                    ZStack(alignment: .leading) {
-                        Rectangle()
-                            .fill(Color.gray.opacity(0.2))
-                            .frame(height: 6)
-                            .cornerRadius(3)
-                        
-                        Rectangle()
-                            .fill(data.color)
-                            .frame(width: max(0, min(1.0, data.progress)) * (geometry.size.width * 0.65))
-                            .frame(height: 6)
-                            .cornerRadius(3)
-                    }
-                }
-                .frame(width: geometry.size.width * 0.65)
-            }
+  let data: WeeklyDayData
+  
+  var body: some View {
+    GeometryReader { geometry in
+      HStack(spacing: 0) {
+        Text(data.day)
+          .foregroundColor(.primary)
+          .frame(width: geometry.size.width * 0.2, alignment: .leading)
+        
+        VStack(spacing: 2) {
+          Text("\(Int(data.progress * 100))%")
+            .foregroundColor(.gray)
+            .frame(maxWidth: .infinity, alignment: .trailing)
+          
+          ZStack(alignment: .leading) {
+            Rectangle()
+              .fill(Color.gray.opacity(0.2))
+              .frame(height: 6)
+              .cornerRadius(3)
+            
+            Rectangle()
+              .fill(data.color)
+              .frame(width: max(0, min(1.0, data.progress)) * (geometry.size.width * 0.8))
+              .frame(height: 6)
+              .cornerRadius(3)
+          }
         }
-        .frame(height: 40)
+        .frame(width: geometry.size.width * 0.8)
+      }
     }
+    .frame(height: 40)
+  }
 }
 
 struct EmptyWeeklyDataView: View {
-    var body: some View {
-        VStack(spacing: 16) {
-            Text("🙂")
-                .font(.system(size: 40))
-            Text("아직 주간 데이터가 없어요.")
-                .font(.title3)
-                .foregroundColor(.gray)
-        }
-        .frame(maxWidth: .infinity, minHeight: 200)
-        .background(Color.white)
-        .cornerRadius(12)
+  var body: some View {
+    VStack(spacing: 16) {
+      Text("아직 주간 데이터가 없어요.")
+        .font(.title3)
+        .foregroundColor(.gray)
     }
+    .frame(maxWidth: .infinity, minHeight: 200)
+    .background(Color.white)
+    .cornerRadius(12)
+  }
 }
 
 struct WeeklyDayData {
-    let day: String
-    let progress: Double
-    let color: Color
-    let emoji: String
+  let day: String
+  let progress: Double
+  let color: Color
 }
 
 #Preview {
-    DashboardWeeklySummaryView(viewModel: DashboardViewModel(
-        uvExposureRepository: MockUVExposureRepository(),
-        weatherRepository: MockWeatherRepository(),
-        userProfileRepository: MockUserProfileRepository(),
-        locationRepository: MockLocationRepository()
-    ))
+  DashboardWeeklySummaryView(viewModel: DashboardViewModel(
+    uvExposureRepository: MockUVExposureRepository(),
+    weatherRepository: MockWeatherRepository(),
+    userProfileRepository: MockUserProfileRepository(),
+    locationRepository: MockLocationRepository()
+  ))
 }

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/GageColor00.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/GageColor00.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x8A",
+          "red" : "0x51"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/GageColor01.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/GageColor01.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x48",
+          "green" : "0x8A",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/Gray00.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/Gray00.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDC",
+          "green" : "0xDC",
+          "red" : "0xDC"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/Gray01.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/Gray01.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF5",
+          "green" : "0xF0",
+          "red" : "0xEC"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/Key00.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/Key00.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x88",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "255",
+          "green" : "255",
+          "red" : "255"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/Key01.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/Key01.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x84",
+          "red" : "0x0A"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/PrimaryRed.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/PrimaryRed.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "2",
+          "green" : "53",
+          "red" : "220"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "255",
+          "green" : "255",
+          "red" : "255"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/SkinType00.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/SkinType00.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDF",
+          "green" : "0xEC",
+          "red" : "0xFC"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/SkinType01.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/SkinType01.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCF",
+          "green" : "0xE2",
+          "red" : "0xFC"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/SkinType02.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/SkinType02.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x9A",
+          "green" : "0xBC",
+          "red" : "0xEC"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/SkinType03.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/SkinType03.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x78",
+          "green" : "0xA4",
+          "red" : "0xEE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/SkinType04.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/SkinType04.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2A",
+          "green" : "0x5E",
+          "red" : "0xA6"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/SkinType05.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/SkinType05.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1D",
+          "green" : "0x20",
+          "red" : "0x39"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/Text00.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/Text00.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3D",
+          "green" : "0x1E",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/Text01.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/Text01.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x8F",
+          "green" : "0x8F",
+          "red" : "0x8F"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/Text02.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/Text02.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x55",
+          "green" : "0x51",
+          "red" : "0x44"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/Text03.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/Text03.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x78",
+          "green" : "0x66",
+          "red" : "0x55"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/Text04.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/Text04.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x76",
+          "green" : "0x76",
+          "red" : "0x76"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/Text05.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/Text05.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB9",
+          "green" : "0xB9",
+          "red" : "0xB9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/WatchBackColor02.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/WatchBackColor02.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x3A",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/White00.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/White00.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/White01.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/White01.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFB",
+          "green" : "0xFA",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TarTanning/TarTanning/Resources/Assets.xcassets/White02.colorset/Contents.json
+++ b/TarTanning/TarTanning/Resources/Assets.xcassets/White02.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFB",
+          "green" : "0xFB",
+          "red" : "0xFB"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #40 

## #️⃣ 작업 내용

> 컬러에셋 전부 추가하고, iOS dashboard 뷰에서 이모지가 들어간 부분을 삭제했습니다.

## #️⃣ 테스트 결과

> 아직 세부적인 디자인 좀 더 수정해야 할 것 같긴 한데...일단 데이터 구조 작업이 더 급해보여서 여기까지 하고 올려요
지금 Weeklydata 부분 1일 전, 2일 전, 이렇게 표시되어 있는데 오늘 어제 금요일 목요일 이렇게 데이터 표시 형식 바꿔야 하고, 게이지 색상도 수정해야 합니다. 색상 부분은 어차피 컬러에셋 적용하면서 다른 뷰들도 전체적으로 다 바꿔야 하니 그때 같이 수정하면 될 것 같습니다.

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> <img width="419" height="697" alt="image" src="https://github.com/user-attachments/assets/846ce20c-7548-4000-82e3-6b96fb680841" />

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요
