### PR TITLE
fix: 일출 전, 일몰 후 알림 오지 않도록 수정

### DIFF
--- a/TarTanning/TarTanning/Domain/Usecases/UVExposure/SyncUVDataInBackgroundUseCase.swift
+++ b/TarTanning/TarTanning/Domain/Usecases/UVExposure/SyncUVDataInBackgroundUseCase.swift
@@ -8,44 +8,77 @@
 import Foundation
 import SwiftData
 
+@MainActor
 struct SyncUVDataInBackgroundUseCase {
     let context: ModelContext
 
-    @MainActor
     func execute() async {
-        print("🚀 [SyncUVDataInBackgroundUseCase] 실행 시작됨")
+        print("🚀 [SyncUVDataInBackgroundUseCase] 백그라운드 UV 동기화 시작")
 
         do {
-            print("🌤️ [Step 1] 날씨 데이터 동기화 시작")
-            let weather = try await SyncWeatherDataUseCase(modelContext: context)
-                .syncWeatherData(for: LocationInfo.mockPohang, type: .backgroundSync)
-            print("✅ [Step 1] 날씨 데이터 동기화 성공 - 시간별 \(weather.hourlyWeathers.count)개")
+            let weather = try await syncWeather()
+            try await syncHealthKit()
+            try await calculateUVDose()
 
-            var uvMap: [Int: Double] = [:]
-            for hour in weather.hourlyWeathers {
-                uvMap[hour.hour] = hour.uvIndex
-            }
-            print("📊 [Step 1] UV Map 구성 완료: \(uvMap)")
-
-            print("🩺 [Step 2] HealthKit 데이터 동기화 시작")
-            try await SyncUVDataFromHealthKitUseCase(modelContext: context).syncTodaySunlightFromHealthKit()
-            print("✅ [Step 2] HealthKit 데이터 동기화 완료")
-
-            print("🧮 [Step 3] UV Dose 계산 및 저장 시작")
-            try await CalculateAndSaveUVDoseUseCase(modelContext: context).calculateAndSaveTodayUVDose()
-            print("✅ [Step 3] UV Dose 계산 및 저장 완료")
-            
-            print("📢 [Step 4] MED 알림 등록 시작")
-            if let dailyUV = try await GetTodayUVExposureUseCase(modelContext: context).getTodayDailyUVExposure() {
-                let maxMED = GetUserProfileUseCase().getUserProfile().skinType.maxMED
-                SendUVWarningNotificationUseCase(uvDose: dailyUV.totalUVDose, maxMED: maxMED).execute()
-            }
-            print("✅ [Step 4] MED 알림 등록 완료")
+            try await handleMEDWarning(weather: weather)
 
             print("🎉 [SyncUVDataInBackgroundUseCase] 전체 백그라운드 작업 완료")
-
         } catch {
-            print("❌ [SyncUVDataInBackgroundUseCase] 백그라운드 UV 싱크 실패: \(error)")
+            print("❌ [SyncUVDataInBackgroundUseCase] 실패: \(error)")
         }
+    }
+
+    // MARK: - Step 1: Weather
+    private func syncWeather() async throws -> LocationWeather {
+        print("🌤️ [Step 1] 날씨 동기화 시작")
+        let weather = try await SyncWeatherDataUseCase(modelContext: context)
+            .syncWeatherData(for: LocationInfo.mockPohang, type: .backgroundSync)
+
+        print("✅ [Step 1] 동기화 성공 - 시간별 \(weather.hourlyWeathers.count)개")
+        return weather
+    }
+
+    // MARK: - Step 2: HealthKit
+    private func syncHealthKit() async throws {
+        print("🩺 [Step 2] HealthKit 데이터 동기화")
+        try await SyncUVDataFromHealthKitUseCase(modelContext: context).syncTodaySunlightFromHealthKit()
+        print("✅ [Step 2] 완료")
+    }
+
+    // MARK: - Step 3: UV Dose
+    private func calculateUVDose() async throws {
+        print("🧮 [Step 3] UV Dose 계산 및 저장")
+        try await CalculateAndSaveUVDoseUseCase(modelContext: context).calculateAndSaveTodayUVDose()
+        print("✅ [Step 3] 완료")
+    }
+
+    // MARK: - Step 4: MED Notification
+    private func handleMEDWarning(weather: LocationWeather) async throws {
+        print("📢 [Step 4] MED 경고 알림 체크")
+
+        guard let dailyUV = try await GetTodayUVExposureUseCase(modelContext: context).getTodayDailyUVExposure() else {
+            print("📭 [Step 4] 오늘 UV 데이터 없음 - 알림 스킵")
+            return
+        }
+
+        guard let sunrise = weather.sunriseTime,
+              let sunset = weather.sunsetTime else {
+            print("⚠️ [Step 4] 일출/일몰 정보 없음 - 알림 스킵")
+            return
+        }
+
+        let now = Date()
+        guard now >= sunrise && now <= sunset else {
+            print("🌙 [Step 4] 현재 야간 - 알림 스킵")
+            return
+        }
+
+        let maxMED = GetUserProfileUseCase().getUserProfile().skinType.maxMED
+        SendUVWarningNotificationUseCase(
+            uvDose: dailyUV.totalUVDose,
+            maxMED: maxMED
+        ).execute()
+
+        print("✅ [Step 4] MED 경고 알림 처리 완료")
     }
 }


### PR DESCRIPTION

## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

(없음)

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

일몰이 지났는데 enableBackgroundDelivery를 어디서 데이터를 가져오길래 알림이 오는 걸까요..
그냥 swiftdata에 저장된 일출 일몰 시간을 기준으로 알림 등록 자체가 안되게 수정해놨습니다.

## #️⃣ 문제 상황

9시가 넘었는데 해가 없는 곳으로 피하래요... 그래서 일몰 이후에 알림 등록 안되게 막았습니다.

![53952E7A-6EC4-4813-9384-BD7F806763CB_4_5005_c](https://github.com/user-attachments/assets/c361453a-add3-41d2-b246-30cdceddb79a)


## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요
